### PR TITLE
updating base URI to use HTTPS, which is now enforced at giantbomb.com

### DIFF
--- a/lib/giantbomb/api.rb
+++ b/lib/giantbomb/api.rb
@@ -2,7 +2,7 @@ module GiantBomb
   module Api
     include HTTParty
 
-    base_uri 'http://www.giantbomb.com/api/'
+    base_uri 'https://www.giantbomb.com/api/'
 
     def self.config
       @@config


### PR DESCRIPTION
Requests to the API over HTTP are redirected to HTTPS and the client doesn't react to that well.